### PR TITLE
chore: 更新 @base-one/prettier-config 版本为 0.0.2，并添加补丁说明

### DIFF
--- a/.changeset/heavy-cities-begin.md
+++ b/.changeset/heavy-cities-begin.md
@@ -2,4 +2,4 @@
 '@base-one/prettier-config': patch
 ---
 
-init perttier-config
+0.0.2


### PR DESCRIPTION
0.0.2